### PR TITLE
expand range of cocktail dependency to include current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cocktail-trait-eventable",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "EventEmitter as delegate trait",
   "main": "lib/Eventable",
   "scripts": {
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "cocktail": "~0.5.1"
+    "cocktail": ""cocktail@>=0.5.1 <0.8.0""
   },
   "devDependencies": {
     "grunt-simple-mocha": "~0.4.0",


### PR DESCRIPTION
With npm 3, this will allow a single copy of cocktail.js to be installed when a project depends on both cocktail and this module, due to the "maximally flat" algorithm used by npm 3. 

Currently using this trait requires an additional older copy of cocktail to be loaded as an additional dependency for projects.
